### PR TITLE
Billing - Email support should be provided with a value

### DIFF
--- a/docs/src/5-prestashop-billing/3-tutorial/README.md
+++ b/docs/src/5-prestashop-billing/3-tutorial/README.md
@@ -181,8 +181,8 @@ You need to inject the `psBillingContext` into the `window.psBillingContext` glo
              'logo' => $partnerLogo,
              'tosLink' => 'https://yoururl/',
              'privacyLink' => 'https://yoururl/',
-             // This field is deprecated, but must be provided to ensure backward compatibility
-             'emailSupport' => ''
+             // This field is deprecated but a valid email must be provided to ensure backward compatibility
+             'emailSupport' => 'some@email.com'
            ]));
 
            $this->context->smarty->assign('urlBilling', "https://unpkg.com/@prestashopcorp/billing-cdc/dist/bundle.js");


### PR DESCRIPTION
When I integrated the billing component on my project, I understood I only had to provide an empty email to make sure previous versions can work properly.
However I just discovered this is not enough and a valid email must be provided. This PR adjusts the comment accordingly.

![image](https://github.com/PrestaShopCorp/docs.cloud.prestashop.com/assets/6768917/301fe460-bc53-46f0-b05b-cd4a8c0a45ae)
